### PR TITLE
Remove unwanted capability restrictions

### DIFF
--- a/debian/peach-network.service
+++ b/debian/peach-network.service
@@ -10,20 +10,18 @@ ExecStart=/usr/bin/peach-network
 Restart=always
 CapabilityBoundingSet=~CAP_SYS_ADMIN CAP_SYS_PTRACE CAP_SYS_BOOT CAP_SYS_TIME CAP_KILL CAP_WAKE_ALARM CAP_LINUX_IMMUTABLE CAP_BLOCK_SUSPEND CAP_LEASE CAP_SYS_NICE CAP_SYS_RESOURCE CAP_RAWIO CAP_CHOWN CAP_FSETID CAP_SETFCAP CAP_DAC_* CAP_FOWNER CAP_IPC_OWNER CAP_SETUID CAP_SETGID CAP_SETPCAP CAP_AUDIT_*
 InaccessibleDirectories=/home
-IPAddressDeny=~127.0.0.1
 LockPersonality=yes
 NoNewPrivileges=yes
+PrivateDevices=yes
 PrivateTmp=yes
 PrivateUsers=yes
 ProtectControlGroups=yes
-ProtectDevices=yes
 ProtectHome=yes
 ProtectKernelModules=yes
 ProtectKernelTunables=yes
 ProtectSystem=yes
 ReadOnlyDirectories=/var
 RestrictAddressFamilies=~AF_INET6 AF_UNIX
-RestrictNamespaces=~CLONE_NEWUSER
 SystemCallFilter=~@reboot @clock @debug @module @mount @swap @resources @privileged
 
 [Install]


### PR DESCRIPTION
Remove capability restrictions which were causing systemd errors (IpAddressDeny and RestrictNamespaces).

Fix incorrectly-named ProtectDevices (should actually be PrivateDevices).