### PR TITLE
Remove extern statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # peach-network
 
-[![Build Status](https://travis-ci.com/peachcloud/peach-network.svg?branch=master)](https://travis-ci.com/peachcloud/peach-network) ![Generic badge](https://img.shields.io/badge/version-0.2.0-<COLOR>.svg)
+[![Build Status](https://travis-ci.com/peachcloud/peach-network.svg?branch=master)](https://travis-ci.com/peachcloud/peach-network) ![Generic badge](https://img.shields.io/badge/version-0.2.1-<COLOR>.svg)
 
 Networking microservice module for PeachCloud. Query and configure device interfaces using [JSON-RPC](https://www.jsonrpc.org/specification) over http.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,11 +13,6 @@
 //! application errors, while `src/lib.rs` contains the JSON-RPC server, RPC
 //! methods, HTTP server and tests.
 //!
-#[macro_use]
-extern crate log;
-extern crate get_if_addrs;
-extern crate wpactrl;
-
 mod error;
 pub mod network;
 
@@ -28,6 +23,7 @@ use jsonrpc_core::{types::error::Error, IoHandler, Params, Value};
 use jsonrpc_http_server::{AccessControlAllowOrigin, DomainsValidation, ServerBuilder};
 #[allow(unused_imports)]
 use jsonrpc_test as test;
+use log::info;
 use serde_json::json;
 
 use crate::error::{BoxError, NetworkError};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,6 @@
-extern crate peach_network;
-#[macro_use]
-extern crate log;
-extern crate env_logger;
-
 use std::process;
+
+use log::error;
 
 fn main() {
     // initalize the logger

--- a/src/network.rs
+++ b/src/network.rs
@@ -13,10 +13,6 @@
 //! system calls to retrieve interface state and write access point credentials
 //! to `wpa_supplicant.conf`.
 //!
-extern crate get_if_addrs;
-extern crate regex;
-extern crate wpactrl;
-
 use std::{
     fs::OpenOptions,
     io::prelude::*,


### PR DESCRIPTION
Remove unnecessary `extern` statements and replace them with `use` where required.