### PR TITLE
Fix wpa_supplicant start bug and bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "peach-network"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "env_logger",
  "failure",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "peach-network"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Andrew Reid <gnomad@cryptolab.net>"]
 edition = "2018"
 description = "Query and configure network interfaces using JSON-RPC over HTTP."

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # peach-network
 
-[![Build Status](https://travis-ci.com/peachcloud/peach-network.svg?branch=master)](https://travis-ci.com/peachcloud/peach-network) ![Generic badge](https://img.shields.io/badge/version-0.2.2-<COLOR>.svg)
+[![Build Status](https://travis-ci.com/peachcloud/peach-network.svg?branch=master)](https://travis-ci.com/peachcloud/peach-network) ![Generic badge](https://img.shields.io/badge/version-0.2.3-<COLOR>.svg)
 
 Networking microservice module for PeachCloud. Query and configure device interfaces using [JSON-RPC](https://www.jsonrpc.org/specification) over http.
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -592,7 +592,7 @@ pub fn activate_client() -> Result<(), NetworkError> {
     // start wpa_supplicant
     Command::new("sudo")
         .arg("/usr/bin/systemctl")
-        .arg("stop")
+        .arg("start")
         .arg("wpa_supplicant")
         .output()
         .context(StopWpaSupplicant)?;


### PR DESCRIPTION
Fixes a very silly bug in the `activate_client()` RPC method, where the `wpa_supplicant` command was `stop` instead of `start`.