### PR TITLE
Improve state handling for status results from wpa_supplicant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "peach-network"
-version = "0.2.5"
+version = "0.2.7"
 dependencies = [
  "env_logger",
  "failure",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "peach-network"
-version = "0.2.5"
+version = "0.2.7"
 authors = ["Andrew Reid <gnomad@cryptolab.net>"]
 edition = "2018"
 description = "Query and configure network interfaces using JSON-RPC over HTTP."

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # peach-network
 
-[![Build Status](https://travis-ci.com/peachcloud/peach-network.svg?branch=master)](https://travis-ci.com/peachcloud/peach-network) ![Generic badge](https://img.shields.io/badge/version-0.2.5-<COLOR>.svg)
+[![Build Status](https://travis-ci.com/peachcloud/peach-network.svg?branch=master)](https://travis-ci.com/peachcloud/peach-network) ![Generic badge](https://img.shields.io/badge/version-0.2.7-<COLOR>.svg)
 
 Networking microservice module for PeachCloud. Query and configure device interfaces using [JSON-RPC](https://www.jsonrpc.org/specification) over http.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@
 //!
 mod error;
 pub mod network;
+mod utils;
 
 use std::env;
 use std::result::Result;

--- a/src/network.rs
+++ b/src/network.rs
@@ -267,13 +267,13 @@ pub fn rssi(iface: &str) -> Result<Option<String>, NetworkError> {
         .open()
         .context(WpaCtrlOpen)?;
     let status = wpa.request("SIGNAL_POLL").context(WpaCtrlRequest)?;
-    let mut status_lines = status.lines();
-    if let Some(rssi_line) = status_lines.next() {
-        // AVG_RSSI fluctuates wildly, use RSSI instead
-        let rssi = rssi_line.to_string().split_off(5);
-        Ok(Some(rssi))
+    let rssi = utils::regex_finder(r"RSSI=(.*)\n", &status)?;
+
+    if rssi.is_none() {
+        let iface = iface.to_string();
+        Err(NetworkError::Rssi { iface })
     } else {
-        Ok(None)
+        Ok(rssi)
     }
 }
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -433,7 +433,7 @@ pub fn status(iface: &str) -> Result<Option<Status>, NetworkError> {
     let wpa_status = wpa.request("STATUS").context(WpaCtrlRequest)?;
 
     // pass the regex pattern and status output to the regex finder
-    let state = utils::regex_finder(r"\nwpa_state=(.*)\n", &wpa_status)?;
+    let state = utils::regex_finder(r"wpa_state=(.*)\n", &wpa_status)?;
     // regex_finder returns an Option type, unwrap or replace None with ERROR
     let wpa_state = state.unwrap_or_else(|| "ERROR".to_string());
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -454,9 +454,18 @@ pub fn status(iface: &str) -> Result<Option<Status>, NetworkError> {
     // create new Status object (all fields are None type by default)
     let mut status = Status::new();
     // match on wpa_state and set Status fields accordingly
+    // we only retrieve additional fields if wpa_state is COMPLETED
     match wpa_state.as_ref() {
+        "UNKNOWN" => status.wpa_state = Some("UNKNOWN".to_string()),
+        "INTERFACE_DISABLED" => status.wpa_state = Some("DISABLED".to_string()),
         "INACTIVE" => status.wpa_state = Some("INACTIVE".to_string()),
         "DISCONNECTED" => status.wpa_state = Some("DISCONNECTED".to_string()),
+        "SCANNING" => status.wpa_state = Some("SCANNING".to_string()),
+        "ASSOCIATING" => status.wpa_state = Some("ASSOCIATING".to_string()),
+        "ASSOCIATED" => status.wpa_state = Some("ASSOCIATED".to_string()),
+        "AUTHENTICATING" => status.wpa_state = Some("AUTHENTICATING".to_string()),
+        "4WAY_HANDSHAKE" => status.wpa_state = Some("4WAY_HANDSHAKE".to_string()),
+        "GROUP_HANDSHAKE" => status.wpa_state = Some("GROUP_HANDSHAKE".to_string()),
         "COMPLETED" => {
             // returns an iterator over the lines in status response
             let mut status_lines = wpa_status.lines();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,22 @@
+use regex::Regex;
+use snafu::ResultExt;
+
+use crate::error::*;
+
+/// Return matches for a given Regex pattern and text
+///
+/// # Arguments
+///
+/// * `pattern` - A string slice containing a regular expression
+/// * `text` - A string slice containing the text to be matched on
+///
+pub fn regex_finder(pattern: &str, text: &str) -> Result<Option<String>, NetworkError> {
+    let re = Regex::new(pattern).context(Regex)?;
+    let caps = re.captures(text);
+    let result = match caps {
+        Some(caps) => Some(caps[1].to_string()),
+        None => None,
+    };
+
+    Ok(result)
+}


### PR DESCRIPTION
Issue reference for this PR: https://github.com/peachcloud/peach-network/issues/15

Instead of panicking when an expected `STATUS` field is not found, we first check the `wpa_state` field in the `STATUS` command response from `wpa_supplicant` (using regex) and act accordingly. This refactored approach now accounts for the `INACTIVE`, `DISCONNECTED` and `COMPLETED` states.

The refactor has been made for the `status()` RPC and must now be replicated for all RPC's which might return unanticipated behaviour based on `wpa_supplicant` state.