### PR TITLE
Add error handling for malformed wpa passphrase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "peach-network"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "env_logger",
  "failure",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "peach-network"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "env_logger",
  "failure",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "peach-network"
-version = "0.2.9"
+version = "0.2.10"
 authors = ["Andrew Reid <gnomad@cryptolab.net>"]
 edition = "2018"
 description = "Query and configure network interfaces using JSON-RPC over HTTP."

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # peach-network
 
-[![Build Status](https://travis-ci.com/peachcloud/peach-network.svg?branch=master)](https://travis-ci.com/peachcloud/peach-network) ![Generic badge](https://img.shields.io/badge/version-0.2.9-<COLOR>.svg)
+[![Build Status](https://travis-ci.com/peachcloud/peach-network.svg?branch=master)](https://travis-ci.com/peachcloud/peach-network) ![Generic badge](https://img.shields.io/badge/version-0.2.10-<COLOR>.svg)
 
 Networking microservice module for PeachCloud. Query and configure device interfaces using [JSON-RPC](https://www.jsonrpc.org/specification) over http.
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -175,7 +175,10 @@ impl From<NetworkError> for Error {
             },
             NetworkError::GenWpaPassphraseWarning { ssid, err_msg } => Error {
                 code: ErrorCode::ServerError(-32027),
-                message: format!("Failed to generate wpa passphrase for {}: {}", ssid, err_msg),
+                message: format!(
+                    "Failed to generate wpa passphrase for {}: {}",
+                    ssid, err_msg
+                ),
                 data: None,
             },
             NetworkError::Id { iface, ssid } => Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -31,6 +31,9 @@ pub enum NetworkError {
     #[snafu(display("Failed to generate wpa passphrase for {}: {}", ssid, source))]
     GenWpaPassphrase { ssid: String, source: io::Error },
 
+    #[snafu(display("Failed to generate wpa passphrase for {}: {}", ssid, err_msg))]
+    GenWpaPassphraseWarning { ssid: String, err_msg: String },
+
     #[snafu(display("No ID found for {} on interface: {}", ssid, iface))]
     Id { ssid: String, iface: String },
 
@@ -168,6 +171,11 @@ impl From<NetworkError> for Error {
             NetworkError::GenWpaPassphrase { ssid, source } => Error {
                 code: ErrorCode::ServerError(-32025),
                 message: format!("Failed to generate wpa passphrase for {}: {}", ssid, source),
+                data: None,
+            },
+            NetworkError::GenWpaPassphraseWarning { ssid, err_msg } => Error {
+                code: ErrorCode::ServerError(-32027),
+                message: format!("Failed to generate wpa passphrase for {}: {}", ssid, err_msg),
                 data: None,
             },
             NetworkError::Id { iface, ssid } => Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -174,7 +174,7 @@ impl From<NetworkError> for Error {
                 data: None,
             },
             NetworkError::GenWpaPassphraseWarning { ssid, err_msg } => Error {
-                code: ErrorCode::ServerError(-32027),
+                code: ErrorCode::ServerError(-32036),
                 message: format!(
                     "Failed to generate wpa passphrase for {}: {}",
                     ssid, err_msg

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,9 +196,12 @@ pub fn run() -> Result<(), BoxError> {
     io.add_method("add", move |params: Params| {
         let w: Result<WiFi, Error> = params.parse();
         match w {
-            Ok(w) => match network::add(&w) {
-                Ok(_) => Ok(Value::String("success".to_string())),
-                Err(_) => Err(Error::from(NetworkError::Add { ssid: w.ssid })),
+            Ok(w) => {
+                let result = network::add(&w);
+                match result {
+                    Ok(_) => Ok(Value::String("success".to_string())),
+                    Err(e) =>           Err(Error::from(e))
+                }
             },
             Err(e) => Err(Error::from(NetworkError::MissingParams { e })),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,8 +197,7 @@ pub fn run() -> Result<(), BoxError> {
         let w: Result<WiFi, Error> = params.parse();
         match w {
             Ok(w) => {
-                let result = network::add(&w);
-                match result {
+                match network::add(&w) {
                     Ok(_) => Ok(Value::String("success".to_string())),
                     Err(e) =>           Err(Error::from(e))
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,11 +196,9 @@ pub fn run() -> Result<(), BoxError> {
     io.add_method("add", move |params: Params| {
         let w: Result<WiFi, Error> = params.parse();
         match w {
-            Ok(w) => {
-                match network::add(&w) {
-                    Ok(_) => Ok(Value::String("success".to_string())),
-                    Err(e) =>           Err(Error::from(e))
-                }
+            Ok(w) => match network::add(&w) {
+                Ok(_) => Ok(Value::String("success".to_string())),
+                Err(e) => Err(Error::from(e)),
             },
             Err(e) => Err(Error::from(NetworkError::MissingParams { e })),
         }

--- a/src/network.rs
+++ b/src/network.rs
@@ -594,9 +594,12 @@ pub fn add(wifi: &WiFi) -> Result<(), NetworkError> {
             //  config file could also be copied from peach/config fs location
             Err(e) => panic!("Failed to write to file: {}", e),
         };
+        Ok(())
     }
-
-    Ok(())
+    else {
+        let err_msg = String::from_utf8_lossy(&output.stdout);
+        Err(NetworkError::GenWpaPassphraseWarning{ ssid: wifi.ssid.to_string(), err_msg: err_msg.to_string()})
+    }
 }
 
 /// Deploy the access point if the `wlan0` interface is `up` without an active

--- a/src/network.rs
+++ b/src/network.rs
@@ -595,10 +595,12 @@ pub fn add(wifi: &WiFi) -> Result<(), NetworkError> {
             Err(e) => panic!("Failed to write to file: {}", e),
         };
         Ok(())
-    }
-    else {
+    } else {
         let err_msg = String::from_utf8_lossy(&output.stdout);
-        Err(NetworkError::GenWpaPassphraseWarning{ ssid: wifi.ssid.to_string(), err_msg: err_msg.to_string()})
+        Err(NetworkError::GenWpaPassphraseWarning {
+            ssid: wifi.ssid.to_string(),
+            err_msg: err_msg.to_string(),
+        })
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -13,10 +13,6 @@ use crate::error::*;
 pub fn regex_finder(pattern: &str, text: &str) -> Result<Option<String>, NetworkError> {
     let re = Regex::new(pattern).context(Regex)?;
     let caps = re.captures(text);
-    let result = match caps {
-        Some(caps) => Some(caps[1].to_string()),
-        None => None,
-    };
-
+    let result = caps.map(|caps| caps[1].to_string());
     Ok(result)
 }


### PR DESCRIPTION
Before, when calling the add function with parameters where wpa_passphrase returned an error, peach-network returned an empty reply (it only created an error if executing wpa_passphrase failed, not if the command returned an error). 

This PR adds error handling that can display the error message returned by wpa_passphrase,
e.g. a response like:
```{"jsonrpc":"2.0","error":{"code":-32027,"message":"Failed to generate wpa passphrase for peacht: Passphrase must be 8..63 characters\n"},"id":1}```